### PR TITLE
fix: add labels support on daemonset

### DIFF
--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -21,6 +21,11 @@ spec:
 {{- end}}
       labels:
         app: twistlock-defender
+{{- if .Values.labels }}
+  {{- range $key, $val := .Values.labels }}
+        {{ $key }}: {{ $val }}
+  {{- end}}
+{{- end}}
     spec:
   {{- if .Values.tolerations }}
       tolerations:

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -67,3 +67,5 @@ tolerations:                                  # Makes pods runnable on all nodes
 #    effect: PreferNoSchedule
 #  - operator: Exists
 #    effect: NoExecute
+labels:                                       # Defender DaemonSet labels
+#  label1: test


### PR DESCRIPTION
## Description

currently there is no support to add labels on the daemonset from values.yaml but we're able to add annotations. This helps us to add additional ownership details and tags

## Motivation and Context
 It helps us to add additional labels on the daemonset

## How Has This Been Tested?

helm template -n twistlock twistlock-defender . -f values.yaml

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- add labels support on daemonset

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
