### PR TITLE
feat: variabilize external-secret properties name

### DIFF
--- a/twistlock-defender/templates/envsecret.yaml
+++ b/twistlock-defender/templates/envsecret.yaml
@@ -20,11 +20,11 @@ spec:
   - secretKey: install_bundle
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: INSTALL_BUNDLE
+      property: {{ .Values.secret_store.properties_name.install_bundle }}
   - secretKey: ws_address
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: WS_ADDRESS
+      property: {{ .Values.secret_store.properties_name.ws_address }}
 {{- else}}
 apiVersion: v1
 kind: Secret

--- a/twistlock-defender/templates/pullsecret.yaml
+++ b/twistlock-defender/templates/pullsecret.yaml
@@ -25,15 +25,15 @@ spec:
   - secretKey: registry
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: REGISTRY
+      property: {{ .Values.secret_store.properties_name.registry }}
   - secretKey: username
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: REGISTRY_USER
+      property: {{ .Values.secret_store.properties_name.username }}
   - secretKey: password
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: REGISTRY_PASS
+      property: {{ .Values.secret_store.properties_name.password }}
 {{- else if or (.Values.registry.dockerconfigjson) (and .Values.registry.name .Values.registry.username .Values.registry.password) }}
 apiVersion: v1
 data:

--- a/twistlock-defender/templates/secret.yaml
+++ b/twistlock-defender/templates/secret.yaml
@@ -29,27 +29,27 @@ spec:
   - secretKey: service_parameter
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: SERVICE_PARAMETER
+      property: {{ .Values.secret_store.properties_name.service_parameter }}
   - secretKey: defender_ca
     remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: DEFENDER_CA
+      property: {{ .Values.secret_store.properties_name.defender_ca }}
   - secretKey: defender_client_cert
-    remoteRef: 
+    remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: DEFENDER_CLIENT_CERT
+      property: {{ .Values.secret_store.properties_name.defender_client_cert }}
   - secretKey: defender_client_key
-    remoteRef: 
+    remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: DEFENDER_CLIENT_KEY
+      property: {{ .Values.secret_store.properties_name.defender_client_key }}
   - secretKey: admission_cert
-    remoteRef: 
+    remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: ADMISSION_CERT
+      property: {{ .Values.secret_store.properties_name.admission_cert }}
   - secretKey: admission_key
-    remoteRef: 
+    remoteRef:
       key: {{ .Values.secret_store.remote_key }}
-      property: ADMISSION_KEY
+      property: {{ .Values.secret_store.properties_name.admission_key }}
 {{- else}}
 apiVersion: v1
 kind: Secret

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -51,6 +51,18 @@ secret_store:                                 # Integrate with External Secrets 
   kind: ClusterSecretStore                    # Secrets Store kind
   refresh_interval: 1h                        # Secrets refresh interval
   remote_key:                                 # Remote secret name for extracting the Defender secrets
+  properties_name:                            # ExternalSecret properties name
+    service_parameter: SERVICE_PARAMETER      # SERVICE_PARAMETER key name on remote secret
+    defender_ca: DEFENDER_CA                  # DEFENDER_CA key name on remote secret
+    defender_client_cert: DEFENDER_CLIENT_CERT # DEFENDER_CLIENT_CERT key name on remote secret
+    defender_client_key: DEFENDER_CLIENT_KEY  # DEFENDER_CLIENT_KEY key name on remote secret
+    admission_cert: ADMISSION_CERT            # ADMISSION_CERT key name on remote secret
+    admission_key: ADMISSION_KEY              # ADMISSION_KEY key name on remote secret
+    registry: REGISTRY                        # image registry url
+    username: REGISTRY_USER                   # image registry user
+    password: REGISTRY_PASS                   # image registry password
+    install_bundle: INSTALL_BUNDLE            # bundle install key name on remote secret
+    ws_address: WS_ADDRESS                    # web service address key name on remote secret
 selinux_header: ""                            # SE Linux header
 selinux_options: ""                           # SE Linux Options
 service_parameter:                            # Service Parameter value. External Secret Key: SERVICE_PARAMETER


### PR DESCRIPTION
## Description

Variabilize properties name in ExternalSecret to be more flexible if secret store keys are not named as expected by chart.

## Motivation and Context
We are migrating some of our code base to FluxCD. The deployment was already managed with another tool and our secret store is not structured as expected by the chart.
This PR aims to allow to allow this customization.

## How Has This Been Tested?

### Test 1 : non regression
```
cd twistlock-defender
git checkout master
cat <<EOF > values-test.yaml
install_bundle: sample_install_bundle
ws_address: sample_ws_address
EOF
helm template . -f values-test.yaml > master.yaml

git checkout ylascombe/twistlock-defender-helm
helm template . -f values-test.yaml > after.yaml
diff master.yaml after.yaml
```

Result
```
diff master.yaml after.yaml
140c140
<           value: "8eb16791-fd3d-40ff-982c-0b259899baeb"
---
>           value: "c3dbed93-3594-4b84-abac-8d0d927bc5dd"
```

### Test 2 : test customization 
```
cat <<EOF > values-test.yaml
install_bundle: sample_install_bundle
ws_address: sample_ws_address
secret_store:
  name: my_secret_store
  kind: ClusterSecretStore
  remote_key: twistlock-defender
  properties_name:
    service_parameter: SERVICE_PARAMETER_TEST_CUSTOM
    defender_ca: DEFENDER_CA_TEST_CUSTOM
    defender_client_cert: DEFENDER_CLIENT_CERT_TEST_CUSTOM
    defender_client_key: DEFENDER_CLIENT_KEY_TEST_CUSTOM
    admission_cert: ADMISSION_CERT_TEST_CUSTOM
    admission_key: ADMISSION_KEY_TEST_CUSTOM
    registry: REGISTRY_TEST_CUSTOM
    username: REGISTRY_USER_TEST_CUSTOM
    password: REGISTRY_PASS_TEST_CUSTOM
    install_bundle: INSTALL_BUNDLE_TEST_CUSTOM
    ws_address: WS_ADDRESS_TEST_CUSTOM
EOF
helm template . -f values-test.yaml > customization.yaml
cat customization.yaml | grep -C 2 TEST_CUSTOM
```

Result:
```
cat customization.yaml | grep -C 2 TEST_CUSTOM
    remoteRef:
      key: twistlock-defender
      property: INSTALL_BUNDLE_TEST_CUSTOM
  - secretKey: ws_address
    remoteRef:
      key: twistlock-defender
      property: WS_ADDRESS_TEST_CUSTOM
---
# Source: twistlock-defender/templates/pullsecret.yaml
--
    remoteRef:
      key: twistlock-defender
      property: REGISTRY_TEST_CUSTOM
  - secretKey: username
    remoteRef:
      key: twistlock-defender
      property: REGISTRY_USER_TEST_CUSTOM
  - secretKey: password
    remoteRef:
      key: twistlock-defender
      property: REGISTRY_PASS_TEST_CUSTOM
---
# Source: twistlock-defender/templates/secret.yaml
--
    remoteRef:
      key: twistlock-defender
      property: SERVICE_PARAMETER_TEST_CUSTOM
  - secretKey: defender_ca
    remoteRef:
      key: twistlock-defender
      property: DEFENDER_CA_TEST_CUSTOM
  - secretKey: defender_client_cert
    remoteRef:
      key: twistlock-defender
      property: DEFENDER_CLIENT_CERT_TEST_CUSTOM
  - secretKey: defender_client_key
    remoteRef:
      key: twistlock-defender
      property: DEFENDER_CLIENT_KEY_TEST_CUSTOM
  - secretKey: admission_cert
    remoteRef:
      key: twistlock-defender
      property: ADMISSION_CERT_TEST_CUSTOM
  - secretKey: admission_key
    remoteRef:
      key: twistlock-defender
      property: ADMISSION_KEY_TEST_CUSTOM
```

## Screenshots (if appropriate)
NA
<!--- What types of changes does your code introduce? -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly. 
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
