### PR TITLE
feat: add support for affinity and resources

### DIFF
--- a/twistlock-defender/Chart.yaml
+++ b/twistlock-defender/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Twistlock Defender Daemon Set Helm Chart
 name: twistlock-defender
 version: 34.0.142
-appVersion: 34.0.142s
+appVersion: 34.0.142
 icon: https://www.paloaltonetworks.com/content/dam/pan/en_US/images/logos/brand/prisma-primary/prisma-primary-card.png?imwidth=1366

--- a/twistlock-defender/Chart.yaml
+++ b/twistlock-defender/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Twistlock Defender Daemon Set Helm Chart
 name: twistlock-defender
-version: 34.0.141
-appVersion: 34.0.141
+version: 34.0.142
+appVersion: 34.0.142s
 icon: https://www.paloaltonetworks.com/content/dam/pan/en_US/images/logos/brand/prisma-primary/prisma-primary-card.png?imwidth=1366

--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -35,6 +35,10 @@ spec:
         {{- end}}
       {{- end}}
   {{- end}}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ .Values.affinity | toYaml | indent 8 }}
+      {{- end }}
       serviceAccountName: twistlock-service
 {{- if .Values.image_pull_secret }}
       imagePullSecrets:
@@ -139,15 +143,16 @@ spec:
             - MKNOD      # A capability to create special files using mknod(2), used by docker-less registry scanning
             - SETFCAP    # A capability to set file capabilities, used by docker-less registry scanning
             - IPC_LOCK   # Required for perf events monitoring, allowing to ignore memory lock limits
-        resources: # See: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled
-          limits:
-            memory: "{{ trimAll "\"" .Values.limit_memory }}"
-            cpu: "{{ trimAll "\"" .Values.limit_cpu }}"
-          requests:
-            {{- if .Values.requests_memory }}
-            memory: "{{ trimAll "\"" .Values.requests_memory }}"
-            {{- end }}
-            cpu: "{{ trimAll "\"" .Values.requests_cpu }}"
+        resources:
+          {{ .Values.resources | toYaml | nindent 10 }} # See: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled
+          # limits:
+          #   memory: "{{ trimAll "\"" .Values.limit_memory }}"
+          #   cpu: "{{ trimAll "\"" .Values.limit_cpu }}"
+          # requests:
+          #   {{- if .Values.requests_memory }}
+          #   memory: "{{ trimAll "\"" .Values.requests_memory }}"
+          #   {{- end }}
+          #   cpu: "{{ trimAll "\"" .Values.requests_cpu }}"
       volumes:
       - name: certificates
         secret:

--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -143,16 +143,15 @@ spec:
             - MKNOD      # A capability to create special files using mknod(2), used by docker-less registry scanning
             - SETFCAP    # A capability to set file capabilities, used by docker-less registry scanning
             - IPC_LOCK   # Required for perf events monitoring, allowing to ignore memory lock limits
-        resources:
-          {{ .Values.resources | toYaml | nindent 10 }} # See: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled
-          # limits:
-          #   memory: "{{ trimAll "\"" .Values.limit_memory }}"
-          #   cpu: "{{ trimAll "\"" .Values.limit_cpu }}"
-          # requests:
-          #   {{- if .Values.requests_memory }}
-          #   memory: "{{ trimAll "\"" .Values.requests_memory }}"
-          #   {{- end }}
-          #   cpu: "{{ trimAll "\"" .Values.requests_cpu }}"
+        resources: # See: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-requests-are-scheduled
+          limits:
+            memory: "{{ trimAll "\"" .Values.limit_memory }}"
+            cpu: "{{ trimAll "\"" .Values.limit_cpu }}"
+          requests:
+            {{- if .Values.requests_memory }}
+            memory: "{{ trimAll "\"" .Values.requests_memory }}"
+            {{- end }}
+            cpu: "{{ trimAll "\"" .Values.requests_cpu }}"
       volumes:
       - name: certificates
         secret:

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -90,10 +90,3 @@ affinity:                                   # Defender DaemonSet affinity
 #          operator: NotIn
 #          values:
 #          - fargate
-resources:
-# requests:
-#   cpu: "256m"                              # CPU Request of the defender
-#   memory: "512Mi"                          # Memory Request of the defender
-# limits:
-#   cpu: "900m"                              # CPU Limits of the defender
-#   memory: "512Mi"                          # Memory Limits of the defender

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -23,10 +23,10 @@ docker_socket_path: /var/run/docker.sock      # Container runtime socket path
 gke_autopilot_annotation: ""                  # GKE autopilot annotation
 host_custom_compliance: false                 # Check custom Compliance for the host
 install_bundle:                               # Defender install bundle. External Secret: INSTALL_BUNDLE
-requests_cpu: '"256m"'                        # CPU Request of the defender
+#requests_cpu: '"256m"'                        # CPU Request of the defender
 # requests_memory: '"512Mi"'                    # Memory Request of the defender
-limit_cpu: '"900m"'                          # CPU Limits of the defender
-limit_memory: '"512Mi"'                      # Memory Limits of the defender
+#limit_cpu: '"900m"'                          # CPU Limits of the defender
+#limit_memory: '"512Mi"'                      # Memory Limits of the defender
 monitor_istio: false                          # Enable Istio Monitoring
 monitor_service_accounts: true                # Enable monitoring of the Service Accounts
 node_selector: ""                             # Node Selector of the defender
@@ -81,3 +81,19 @@ tolerations:                                  # Makes pods runnable on all nodes
 #    effect: NoExecute
 labels:                                       # Defender DaemonSet labels
 #  label1: test
+affinity:                                   # Defender DaemonSet affinity
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#      - matchExpressions:
+#        - key: eks.amazonaws.com/compute-type
+#          operator: NotIn
+#          values:
+#          - fargate
+resources:
+# requests:
+#   cpu: "256m"                              # CPU Request of the defender
+#   memory: "512Mi"                          # Memory Request of the defender
+# limits:
+#   cpu: "900m"                              # CPU Limits of the defender
+#   memory: "512Mi"                          # Memory Limits of the defender


### PR DESCRIPTION
## Description

- Add support for affinity rules to set tolerations and exclude any other node types
- Add Support to have flexibility for not setting the CPU limits

## Motivation and Context

Adding the above features will help resolve the daemonsets to schedule on nodes that have taints and also avoiding  to schedule the daemonsets on certain types of nodes