### PR TITLE
Enable ability for helm users to add env vars via values file

### DIFF
--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -126,6 +126,17 @@ spec:
         - name: FIPS_ENABLED
           value: "{{ .Values.FIPS_ENABLED }}"
 {{- end }}
+{{- if .Values.extraEnv }}
+{{- range .Values.extraEnv }}
+        - name: {{ .name }}
+{{- if .value }}
+          value: {{ .value | quote }}
+{{- else if .valueFrom }}
+          valueFrom:
+{{ .valueFrom | toYaml | indent 12 }}
+{{- end }}
+{{- end }}
+{{- end }}
         securityContext:
           readOnlyRootFilesystem: true
           privileged: {{ .Values.privileged }}

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -96,6 +96,13 @@ talos: false                                  # Verify if it's TalOS deployment
 twistlock_data_folder: /var/lib/twistlock     # Container folder where the defender data will be located
 unique_hostname: true                         # Assign unique host names
 ws_address:                                   # Web Socket address. External Secret Key: WS_ADDRESS
+extraEnv: []                                  # Additional environment variables for the defender container
+#  - name: HTTP_PROXY
+#    value: "http://proxy.example.com:8080"
+#  - name: HTTPS_PROXY
+#    value: "http://proxy.example.com:8080"
+#  - name: NO_PROXY
+#    value: "localhost,127.0.0.1,.cluster.local"
 annotations:                                  # Defender DaemonSet annotations
 #  annotation1: test
 tolerations:                                  # Makes pods runnable on all nodes including master node.


### PR DESCRIPTION
## Description

We are helm users of twistlock, and have to break out kustomize to add in proxy config. The ability to specify extraEnvVars would allow us to turn that side off and just use the plain helm chart. 

## Motivation and Context

The kustomize approach can be brittle and break if the helm chart is refactored. 

## How Has This Been Tested?

Local helm templating.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
