### PR TITLE
fix: quote values for annotations and labels

### DIFF
--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -16,14 +16,14 @@ spec:
 {{- end }}
 {{- if .Values.annotations }}
   {{- range $key, $val := .Values.annotations }}
-        {{ $key }}: {{ $val }}
+        {{ $key }}: {{ $val | quote }}
   {{- end }}
 {{- end }}
       labels:
         app: twistlock-defender
 {{- if .Values.labels }}
   {{- range $key, $val := .Values.labels }}
-        {{ $key }}: {{ $val }}
+        {{ $key }}: {{ $val | quote }}
   {{- end }}
 {{- end }}
     spec:


### PR DESCRIPTION
Quote annotation and label values in daemonset.yaml.

## Description

<!--- Describe your changes in detail -->
This forces the values for labels and annotation to be a string, following Helm best practices. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
You will get an error from helm if for example your label value is a number like "123456". It will try to read it in as number instead of a string. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the chart locally with this change and installed to an EKS cluster to make sure it works. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
